### PR TITLE
chore: remove useless imports

### DIFF
--- a/src/internal/chatgpt.rs
+++ b/src/internal/chatgpt.rs
@@ -9,7 +9,6 @@ use std::collections::HashSet;
 use hyper::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use hyper::{Body, Client, Request, Uri};
 use hyper_tls::HttpsConnector;
-use log::debug;
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Though compiles successfully, cargo complains "unused imports":
```bash
$ OPENAI_API_KEY=<...> /Users/lei/.cargo/bin/cargo test --color=always --package gpt-macro --test tests "" 
warning: unused import: `log::debug`
  --> src/internal/chatgpt.rs:12:5
   |
12 | use log::debug;
   |     ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `gpt-macro` (lib) generated 1 warning
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running tests/tests.rs (target/debug/deps/tests-289b39449a0fcc46)

running 1 test
warning: unused import: `log::debug`
  --> /Users/lei/Workspace/Rust/gpt-macro/src/internal/chatgpt.rs:12:5
   |
12 | use log::debug;
   |     ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `gpt-macro` (lib) generated 1 warning
   Compiling gpt-macro-tests v0.0.0 (/Users/lei/Workspace/Rust/gpt-macro/target/tests/trybuild/gpt-macro)
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s


test tests/auto_test_fn.rs ... ok

STDERR:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
warning: unused import: `log::debug`
  --> /Users/lei/Workspace/Rust/gpt-macro/src/internal/chatgpt.rs:12:5
   |
12 | use log::debug;
   |     ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

test tests/auto_impl_fn.rs ... ok

STDERR:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
warning: unused import: `log::debug`
  --> /Users/lei/Workspace/Rust/gpt-macro/src/internal/chatgpt.rs:12:5
   |
12 | use log::debug;
   |     ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈



test tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.56s

```