### PR TITLE
Enable chat completion feature for async-openai

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ trybuild = { version = "1.0", features = ["diff"] }
 syn = { version = "2.0", features = ["full", "extra-traits", "parsing"] }
 proc-macro2 = { version = "1.0", features = ["nightly"] }
 quote = "1.0"
-async-openai = "0.31.1"
+async-openai = { version = "0.31.1", features = ["chat-completion"] }
 tokio = { version = "1.0", features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- enable the async-openai chat-completion feature to pull in the API types required by the macros

## Testing
- cargo test *(fails: network error fetching crates.io dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932df9beba88320b295bf9f3b94a94b)